### PR TITLE
fixed room selector approach

### DIFF
--- a/src/routes/Lobby.tsx
+++ b/src/routes/Lobby.tsx
@@ -123,10 +123,6 @@ function Lobby({
             aria-label="Tabs"
             role="tablist"
             aria-orientation="horizontal"
-            onFocus={(e: any) => {
-              setSelectedInput(e.target.value);
-              console.log("roomselected", e.target.value);
-            }}
           >
             {gameList.map((game) => (
               <button
@@ -137,6 +133,10 @@ function Lobby({
                 data-hs-tab="#vertical-tab-with-border-1"
                 aria-controls="vertical-tab-with-border-1"
                 role="tab"
+                onClick={(e: any) => {
+                  setSelectedInput(game);
+                  console.log("roomselected", e.target.value);
+                }}
                 value={game}
               >
                 {game}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit cc76b2fd3c304e294cda28d9f18eafe11b5e6bb8  | 
|--------|--------|

### Summary:
The PR updates the `Lobby` component in `src/routes/Lobby.tsx` to use `onClick` instead of `onFocus` for setting the `selectedInput` state when selecting a room.

**Key points**:
- Removed `onFocus` event handler from room selection buttons in `src/routes/Lobby.tsx`.
- Added `onClick` event handler to room selection buttons to set `selectedInput` state.
- Logs the selected room value to the console on click.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->